### PR TITLE
Fixed the rounding instructions for `monthlyRateFrom()` function.

### DIFF
--- a/exercises/concept/freelancer-rates/.docs/instructions.md
+++ b/exercises/concept/freelancer-rates/.docs/instructions.md
@@ -27,7 +27,7 @@ There is in total  **_22 workdays_**.
 Help the freelancer calculate their monthly rate given their hourly rate and the discount they are willing to give, rounded to the nearest whole number.
 
 Implement the function `monthlyRateFrom(hourlyRate:withDiscount:)`, that takes the arguments `hourlyRate` which holds the freelancers hourly rate, and `withDiscount` which holds the discount the freelancer is willing to give to the client.
-The function should return the monthly rate rounded down.
+The function should return the monthly rate rounded to the nearest whole number.
 
 ```swift
 monthlyRateFrom(hourlyRate: 77, withDiscount: 10.5)


### PR DESCRIPTION
Prior to rounding the `monthlyRateFrom()` function should have a value of `12601.6` given the values in the test...

https://github.com/exercism/swift/blob/19b3d8f6afdb5f34629a55bf80e8ffa4e079c87c/exercises/concept/freelancer-rates/Tests/FreelancerRatesTests/FreelancerRatesTests.swift#L34C13-L37

If, (as the instructions say) this value is rounded down the result would be `12601.0` not the expected `12602.0`.